### PR TITLE
Add `.dockerignore` as symlink of `.gitignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore


### PR DESCRIPTION
Thank you to @johnclary for pointing out that this was missing from this repo. You saved us a ton of headache with an ounce of prevention. :pray: 

## Testing

For testing, please checkout the branch and `cat .dockerignore` to see the contents of the file. Edits to `.gitignore` should be instantly and automatically reflected when you `cat .dockerignore` again, and _vice versa_. 