### PR TITLE
Include missing field in NBP field_maps

### DIFF
--- a/utils/field_maps.py
+++ b/utils/field_maps.py
@@ -94,6 +94,7 @@ FIELD_MAPS = {
             "BLOCK_PARTY": {
                 "payment_received": "field_845",
                 "payment_date": "field_844",
+                "application_status": "field_704"
             },
         },
         "UAT": {


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/24984

Hanna alerted me that a Neighborhood Block Party payment did not update the knack parent application nor the transaction table. 

I checked the cloudwatch logs and 

```
  File "/root/app/app.py", line 184, in update_parent_reservation
    knack_fields["application_status"]: "Complete - Permit Issued",
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'application_status'
```

While I had added the application_status field to UAT, I neglected to add it to prod, and did not check prod fields before releasing since the knack app is doing double duty for prod and uat. 

After this is merged, I will open a PR to push main to production.