### PR TITLE
Update readme post go live / block party launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Flask based endpoint ("the postback") used to update Knack transaction records b
 Citybase is the payment provider for two Knack apps, Street Banners and Neighborhood Block Parties in Smart Mobility.
 Once a reservation is created and approved in the Knack app, an invoice is generated and marked as ready to pay. Custom javascript ([example](https://github.com/cityofaustin/atd-knack/blob/master/code/street-banner/street-banner.js#L417)) creates a payload to send to the [Citybase endpoint](https://invoice-service.prod.cityba.se/invoices/austin_tx_transportation/street_banner). This request responds with a url to process the payment request. Note, the amount must be in pennies.
 
-Once a user has completed the payment transaction, Citybase sends a payload and waits for a 200 reply.
+Once a user has completed the payment transaction, Citybase send a `POST` request with a payload and waits for a 200 reply.
 
 The postback inserts a record in the citybase_messages table in the appropriate Knack app.
 It then updates the transactions table, either by updating the status of the existing transaction or in the case of a refund, inserting a new record.
@@ -104,7 +104,7 @@ In the root of the git repository, please:
 
 Logs that are emitted are also sent to AWS Cloudwatch using [watchtower/](https://pypi.org/project/watchtower/), the log groups are named based on the environment variable used when spinning up the stack, `/dts/citybase/postback/{knack_env}`. Log streams are named based on the date in the YYYY/mm/dd format. Development logs have a 3 day retention rate, production and staging logs never expire.
 
-There is a Metric filter for the /dts/citybase/postback/production cloudwatch log so that if it finds a 500 in the log stream, it will send an email to [Chia](https://github.com/chiaberry)
+There is a Metric filter for the /dts/citybase/postback/production cloudwatch log so that if it finds a 500 in the log stream, it will send an email to [Chia](https://github.com/chiaberry).
 
 ## Deployment lifecycle
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Logs that are emitted are also sent to AWS Cloudwatch using [watchtower/](https:
 
 There is a Metric filter for the /dts/citybase/postback/production cloudwatch log so that if it finds a 500 in the log stream, it will send an email to [Chia](https://github.com/chiaberry).
 
+### SSL
+
+Certificate renewal is handled by certbot, see https://github.com/cityofaustin/dts-services-haproxy/tree/main/toolbox/certbot
+
 ## Deployment lifecycle
 
 This project moves through four phases: development → staging → UAT → production. The `main` branch is the integration branch and should always be the most up to date (ahead of `uat` and `production`). Feature work happens on short‑lived branches and is merged into `main` via pull request.

--- a/README.md
+++ b/README.md
@@ -4,68 +4,84 @@ Healthcheck url, must be on city network: https://citybase.austinmobility.io/
 
 ## Description
 
-Flask based endpoint used to update Knack transaction records based on events delivered by Citybase.
+Flask based endpoint ("the postback") used to update Knack transaction records based on events delivered by Citybase.
 
 ## Integration with Knack
 
-Citybase is the payment provider for the Over the Street and Lamppost Banner invoices.
+Citybase is the payment provider for two Knack apps, Street Banners and Neighborhood Block Parties in Smart Mobility.
 Once a reservation is created and approved in the Knack app, an invoice is generated and marked as ready to pay. Custom [javascript](https://github.com/cityofaustin/atd-knack/blob/master/code/street-banner/street-banner.js#L417) creates a payload to send to the [Citybase endpoint](https://invoice-service.prod.cityba.se/invoices/austin_tx_transportation/street_banner). This request responds with a url to process the payment request. Note, the amount must be in pennies.
 
-Once a user has completed the payment transaction, Citybase sends a postback and waits for us to confirm receipt. Citybase does not consider the payment complete until it receives a 200 response to the request.
+Once a user has completed the payment transaction, Citybase sends a payload and waits for a 200 reply.
 
-The app inserts a record in the citybase_messages table in the Street Banners Knack app.
+The postback inserts a record in the citybase_messages table in the appropriate Knack app.
 It then updates the transactions table, either by updating the status of the existing transaction or in the case of a refund, inserting a new record.
 
 If the transaction is PAID, then the parent reservation is also updated in knack.
 
 The response from the transaction update is then sent back to citybase.
 
-Example citybase payload
+Example payload from citybase to postback:
 
 ```json
-{
-  "data": {
-    "total_amount": 6000.0,
-    "service_fee": 0.55,
-    "amount": 6000.0,
-    "voidable": true,
-    "refundable": false,
-    "id": 70022195,
-    "payment_source_channel": "web",
-    "status": "refunded",
-    "request_id": "not used",
-    "payment_type": "credit_card",
-    "agency": "Austin Transportation",
-    "credit_card": {
-      "last_four": "1111",
-      "card_type": "visa"
-    },
-    "bank_account": null,
-    "created_at": "2022-10-13T17:58:00Z",
-    "line_items": [
-      {
-        "id": "deea9dae-0121-49dc-be59-c3b40dccdb3d",
-        "amount": 600000,
-        "custom_attributes": {
-          "invoice_number": "INV2022-100250",
-          "knack_record_id": "638e5bd41370e500241c3e1f",
-          "line_item_description": "Lamppost my big winter event",
-          "line_item_sub_description": "INV2022-100250 - convention center"
-        }
-      }
-    ],
-    "associated_payments": [],
-    "custom_attributes": [
-      {
-        "key": "invoice_number",
-        "value": "INV2022-100250"
+ {
+   "data":{
+      "total_amount":50.55,
+      "service_fee":0.55,
+      "amount":50.0,
+      "voidable":false,
+      "refundable": true,
+      "id":70020064,
+      "payment_source_channel":"web",
+      "status":"successful",
+      "request_id":"not used",
+      "payment_type":"check",
+      "agency":"Austin Transportation",
+      "credit_card":null,
+      "bank_account":{
+         "account_number_last_four":"1234",
+         "routing_number":"00000000",
+         "bank_account_type":"checking",
+         "account_holder_name":"fake person today"
       },
-      {
-        "key": "knack_record_id",
-        "value": "638e5bd41370e500241c3e1f"
-      }
-    ]
-  }
+      "check_number": null,
+      "created_at":"2025-08-18T19:17:09Z",
+      "line_items":[
+         {
+            "id":"3c45f190-6bd3-4b7a-8062-c8bd21d9a359",
+            "amount":5000,
+            "custom_attributes":{
+               "dept":"6200",
+               "fund":"5120",
+               "unit":"9400",
+               "revenue":"4502",
+               "invoice_number":"INV1970-100040",
+               "knack_record_id":"6883b7b282a48402f6eb4a9e",
+               "line_item_description":"NBP 0094 | Party Date 09/19/2025 - Chia B",
+               "line_item_sub_description":"NBP 0094 | Party Date 09/19/2025 - Chia B"
+            }
+         }
+      ],
+      "associated_payments":[
+      ],
+      "custom_attributes":[
+         {
+            "key":"knack_app",
+            "value":"SMART_MOBILITY"
+         },
+         {
+            "key":"invoice_number",
+            "value":"INV1970-100040"
+         },
+         {
+            "key":"knack_record_id",
+            "value":"6883b7b282a48402f6eb4a9e"
+         },
+				 {
+            "key":"parent_record_id",
+            "value":"6883b7b282a48402f6eb4a9e"
+         }
+      ]
+   }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Flask based endpoint ("the postback") used to update Knack transaction records b
 ## Integration with Knack
 
 Citybase is the payment provider for two Knack apps, Street Banners and Neighborhood Block Parties in Smart Mobility.
-Once a reservation is created and approved in the Knack app, an invoice is generated and marked as ready to pay. Custom javascript [example](https://github.com/cityofaustin/atd-knack/blob/master/code/street-banner/street-banner.js#L417) creates a payload to send to the [Citybase endpoint](https://invoice-service.prod.cityba.se/invoices/austin_tx_transportation/street_banner). This request responds with a url to process the payment request. Note, the amount must be in pennies.
+Once a reservation is created and approved in the Knack app, an invoice is generated and marked as ready to pay. Custom javascript ([example](https://github.com/cityofaustin/atd-knack/blob/master/code/street-banner/street-banner.js#L417)) creates a payload to send to the [Citybase endpoint](https://invoice-service.prod.cityba.se/invoices/austin_tx_transportation/street_banner). This request responds with a url to process the payment request. Note, the amount must be in pennies.
 
 Once a user has completed the payment transaction, Citybase sends a payload and waits for a 200 reply.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Flask based endpoint ("the postback") used to update Knack transaction records b
 ## Integration with Knack
 
 Citybase is the payment provider for two Knack apps, Street Banners and Neighborhood Block Parties in Smart Mobility.
-Once a reservation is created and approved in the Knack app, an invoice is generated and marked as ready to pay. Custom [javascript](https://github.com/cityofaustin/atd-knack/blob/master/code/street-banner/street-banner.js#L417) creates a payload to send to the [Citybase endpoint](https://invoice-service.prod.cityba.se/invoices/austin_tx_transportation/street_banner). This request responds with a url to process the payment request. Note, the amount must be in pennies.
+Once a reservation is created and approved in the Knack app, an invoice is generated and marked as ready to pay. Custom javascript [example](https://github.com/cityofaustin/atd-knack/blob/master/code/street-banner/street-banner.js#L417) creates a payload to send to the [Citybase endpoint](https://invoice-service.prod.cityba.se/invoices/austin_tx_transportation/street_banner). This request responds with a url to process the payment request. Note, the amount must be in pennies.
 
 Once a user has completed the payment transaction, Citybase sends a payload and waits for a 200 reply.
 
@@ -103,6 +103,8 @@ In the root of the git repository, please:
 ### Logging
 
 Logs that are emitted are also sent to AWS Cloudwatch using [watchtower/](https://pypi.org/project/watchtower/), the log groups are named based on the environment variable used when spinning up the stack, `/dts/citybase/postback/{knack_env}`. Log streams are named based on the date in the YYYY/mm/dd format. Development logs have a 3 day retention rate, production and staging logs never expire.
+
+There is a Metric filter for the /dts/citybase/postback/production cloudwatch log so that if it finds a 500 in the log stream, it will send an email to [Chia](https://github.com/chiaberry)
 
 ## Deployment lifecycle
 


### PR DESCRIPTION
I realized recently that I never updated the readme post go live and changes to the postback. (I did include barebones release notes though! https://github.com/cityofaustin/atd-citybase/releases/tag/v2.0)

This updates the app's description to include both Knack apps and updates the sample payload. 